### PR TITLE
Implement WPF screenshot tool according to planning document

### DIFF
--- a/WpfScreenshotApp.sln
+++ b/WpfScreenshotApp.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfScreenshotApp", "src\\WpfScreenshotApp\\WpfScreenshotApp.csproj", "{53C3B8A9-0B9D-4A69-91E4-F0A90C9623F2}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {53C3B8A9-0B9D-4A69-91E4-F0A90C9623F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {53C3B8A9-0B9D-4A69-91E4-F0A90C9623F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {53C3B8A9-0B9D-4A69-91E4-F0A90C9623F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {53C3B8A9-0B9D-4A69-91E4-F0A90C9623F2}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal

--- a/src/WpfScreenshotApp/App.xaml
+++ b/src/WpfScreenshotApp/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="WpfScreenshotApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             ShutdownMode="OnExplicitShutdown">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/src/WpfScreenshotApp/App.xaml.cs
+++ b/src/WpfScreenshotApp/App.xaml.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Windows;
+using System.Windows.Input;
+using WpfScreenshotApp.Services;
+
+namespace WpfScreenshotApp;
+
+public partial class App : Application
+{
+    private TrayIconService? _trayIconService;
+    private HotkeyService? _hotkeyService;
+    private ScreenshotService? _screenshotService;
+
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+        ShutdownMode = ShutdownMode.OnExplicitShutdown;
+
+        var clipboardService = new ClipboardService();
+        var stickyImageService = new StickyImageService();
+        _screenshotService = new ScreenshotService(clipboardService, stickyImageService);
+
+        _trayIconService = new TrayIconService();
+        _trayIconService.Initialize("WPF Screenshot Tool", OnExitRequested, OnTakeScreenshotRequested, OnSaveScreenshotRequested);
+
+        _hotkeyService = new HotkeyService();
+        _hotkeyService.HotkeyPressed += (_, _) => StartCapture();
+        if (!_hotkeyService.RegisterHotkey(ModifierKeys.Control | ModifierKeys.Alt, System.Windows.Forms.Keys.End))
+        {
+            MessageBox.Show("无法注册全局热键 Ctrl+Alt+End，可能已被其他程序占用。", "WPF Screenshot", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+
+        Dispatcher.BeginInvoke(new Action(() => _trayIconService?.ShowBalloonTip("已启动", "按 Ctrl+Alt+End 开始截图")));
+    }
+
+    private void StartCapture()
+    {
+        if (_screenshotService == null)
+        {
+            return;
+        }
+
+        Dispatcher.Invoke(() =>
+        {
+            _screenshotService.StartCapture();
+        });
+    }
+
+    private void OnTakeScreenshotRequested()
+    {
+        StartCapture();
+    }
+
+    private void OnSaveScreenshotRequested()
+    {
+        _screenshotService?.PromptSaveLatestCapture();
+    }
+
+    private void OnExitRequested()
+    {
+        _hotkeyService?.Dispose();
+        _trayIconService?.Dispose();
+        _screenshotService?.Dispose();
+        Shutdown();
+    }
+}

--- a/src/WpfScreenshotApp/Interop/NativeMethods.cs
+++ b/src/WpfScreenshotApp/Interop/NativeMethods.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace WpfScreenshotApp.Interop;
+
+internal static class NativeMethods
+{
+    public const int WM_HOTKEY = 0x0312;
+
+    [Flags]
+    public enum HotKeyModifiers : uint
+    {
+        None = 0,
+        Alt = 0x0001,
+        Control = 0x0002,
+        Shift = 0x0004,
+        Win = 0x0008
+    }
+
+    [DllImport("user32.dll")]
+    public static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+
+    [DllImport("user32.dll")]
+    public static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+}

--- a/src/WpfScreenshotApp/Models/ScreenshotResult.cs
+++ b/src/WpfScreenshotApp/Models/ScreenshotResult.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Windows;
+using System.Windows.Media.Imaging;
+
+namespace WpfScreenshotApp.Models;
+
+public class ScreenshotResult
+{
+    public ScreenshotResult(BitmapSource image, Rect area)
+    {
+        Image = image;
+        Area = area;
+        CapturedAt = DateTime.Now;
+    }
+
+    public BitmapSource Image { get; }
+
+    public Rect Area { get; }
+
+    public DateTime CapturedAt { get; }
+
+    public string? SavedFilePath { get; set; }
+}

--- a/src/WpfScreenshotApp/Services/ClipboardService.cs
+++ b/src/WpfScreenshotApp/Services/ClipboardService.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+using System.Windows.Media.Imaging;
+
+namespace WpfScreenshotApp.Services;
+
+public class ClipboardService
+{
+    public void CopyImage(BitmapSource image)
+    {
+        Clipboard.SetImage(image);
+    }
+}

--- a/src/WpfScreenshotApp/Services/HotkeyService.cs
+++ b/src/WpfScreenshotApp/Services/HotkeyService.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Windows;
+using System.Windows.Forms;
+using System.Windows.Interop;
+using WpfScreenshotApp.Interop;
+using ModifierKeys = System.Windows.Input.ModifierKeys;
+
+namespace WpfScreenshotApp.Services;
+
+public sealed class HotkeyService : IDisposable
+{
+    private readonly int _hotkeyId;
+    private HwndSource? _source;
+    private Window? _messageWindow;
+    private bool _registered;
+
+    public event EventHandler? HotkeyPressed;
+
+    public HotkeyService()
+    {
+        _hotkeyId = GetHashCode();
+    }
+
+    public bool RegisterHotkey(ModifierKeys modifiers, Keys key)
+    {
+        if (_registered)
+        {
+            return true;
+        }
+
+        _messageWindow = new Window
+        {
+            Visibility = Visibility.Hidden,
+            ShowInTaskbar = false,
+            Width = 0,
+            Height = 0,
+            WindowStyle = WindowStyle.None
+        };
+
+        _messageWindow.Show();
+        _messageWindow.Hide();
+
+        var helper = new WindowInteropHelper(_messageWindow);
+        _source = HwndSource.FromHwnd(helper.Handle);
+        if (_source == null)
+        {
+            _messageWindow.Close();
+            _messageWindow = null;
+            return false;
+        }
+
+        _source.AddHook(WndProc);
+        var mods = ConvertModifiers(modifiers);
+        _registered = NativeMethods.RegisterHotKey(_source.Handle, _hotkeyId, (uint)mods, (uint)key);
+        if (!_registered)
+        {
+            _source.RemoveHook(WndProc);
+            _messageWindow?.Close();
+            _messageWindow = null;
+        }
+
+        return _registered;
+    }
+
+    public void UnregisterHotkey()
+    {
+        if (_registered && _source != null)
+        {
+            NativeMethods.UnregisterHotKey(_source.Handle, _hotkeyId);
+            _source.RemoveHook(WndProc);
+            _source.Dispose();
+            _source = null;
+            _registered = false;
+        }
+
+        if (_messageWindow != null)
+        {
+            _messageWindow.Close();
+            _messageWindow = null;
+        }
+    }
+
+    private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        if (msg == NativeMethods.WM_HOTKEY && wParam.ToInt32() == _hotkeyId)
+        {
+            handled = true;
+            HotkeyPressed?.Invoke(this, EventArgs.Empty);
+        }
+
+        return IntPtr.Zero;
+    }
+
+    private static NativeMethods.HotKeyModifiers ConvertModifiers(ModifierKeys modifiers)
+    {
+        var result = NativeMethods.HotKeyModifiers.None;
+
+        if (modifiers.HasFlag(ModifierKeys.Alt))
+        {
+            result |= NativeMethods.HotKeyModifiers.Alt;
+        }
+
+        if (modifiers.HasFlag(ModifierKeys.Control))
+        {
+            result |= NativeMethods.HotKeyModifiers.Control;
+        }
+
+        if (modifiers.HasFlag(ModifierKeys.Shift))
+        {
+            result |= NativeMethods.HotKeyModifiers.Shift;
+        }
+
+        if (modifiers.HasFlag(ModifierKeys.Windows))
+        {
+            result |= NativeMethods.HotKeyModifiers.Win;
+        }
+
+        return result;
+    }
+
+    public void Dispose()
+    {
+        UnregisterHotkey();
+    }
+}

--- a/src/WpfScreenshotApp/Services/ScreenshotService.cs
+++ b/src/WpfScreenshotApp/Services/ScreenshotService.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Media.Imaging;
+using Microsoft.Win32;
+using WpfScreenshotApp.Models;
+using WpfScreenshotApp.Views;
+using Application = System.Windows.Application;
+using Point = System.Windows.Point;
+using Rectangle = System.Drawing.Rectangle;
+
+namespace WpfScreenshotApp.Services;
+
+public class ScreenshotService : IDisposable
+{
+    private readonly ClipboardService _clipboardService;
+    private readonly StickyImageService _stickyImageService;
+    private ScreenshotResult? _latestResult;
+    private OverlayWindow? _overlayWindow;
+    private FloatingToolbarWindow? _toolbarWindow;
+    private Bitmap? _fullScreenshot;
+    private Rect _virtualBounds;
+
+    public ScreenshotService(ClipboardService clipboardService, StickyImageService stickyImageService)
+    {
+        _clipboardService = clipboardService;
+        _stickyImageService = stickyImageService;
+    }
+
+    public void StartCapture()
+    {
+        if (_overlayWindow != null)
+        {
+            return;
+        }
+
+        _virtualBounds = GetVirtualScreenBounds();
+        _fullScreenshot = CaptureVirtualScreen(_virtualBounds);
+        var preview = ConvertToBitmapSource(_fullScreenshot);
+
+        _overlayWindow = new OverlayWindow(preview, _virtualBounds);
+        _overlayWindow.SelectionCompleted += OnSelectionCompleted;
+        _overlayWindow.SelectionCanceled += OnSelectionCanceled;
+        _overlayWindow.Closed += (_, _) => ClearOverlay();
+        _overlayWindow.Show();
+        _overlayWindow.Activate();
+    }
+
+    public void PromptSaveLatestCapture()
+    {
+        if (_latestResult == null)
+        {
+            System.Windows.MessageBox.Show("没有可以保存的截图。", "WPF Screenshot", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        SaveScreenshot(_latestResult);
+    }
+
+    private void OnSelectionCompleted(object? sender, Rect rect)
+    {
+        if (_overlayWindow == null || _fullScreenshot == null)
+        {
+            return;
+        }
+
+        var cropRect = new Rectangle(
+            (int)Math.Round(rect.X - _virtualBounds.Left),
+            (int)Math.Round(rect.Y - _virtualBounds.Top),
+            (int)Math.Round(rect.Width),
+            (int)Math.Round(rect.Height));
+
+        cropRect.Intersect(new Rectangle(0, 0, _fullScreenshot.Width, _fullScreenshot.Height));
+        if (cropRect.Width <= 0 || cropRect.Height <= 0)
+        {
+            return;
+        }
+
+        using var croppedBitmap = _fullScreenshot.Clone(cropRect, PixelFormat.Format32bppArgb);
+        var bitmapSource = ConvertToBitmapSource(croppedBitmap);
+        _latestResult = new ScreenshotResult(bitmapSource, rect);
+
+        Application.Current.Dispatcher.Invoke(() =>
+        {
+            _clipboardService.CopyImage(bitmapSource);
+        });
+
+        ShowToolbar(rect);
+        _overlayWindow.Close();
+    }
+
+    private void OnSelectionCanceled(object? sender, EventArgs e)
+    {
+        _overlayWindow?.Close();
+    }
+
+    private void ShowToolbar(Rect selectionRect)
+    {
+        CloseToolbar();
+        if (_latestResult == null)
+        {
+            return;
+        }
+
+        _toolbarWindow = new FloatingToolbarWindow();
+        _toolbarWindow.PinRequested += (_, _) => PinLatest();
+        _toolbarWindow.EditRequested += (_, _) => EditLatest();
+        _toolbarWindow.SaveRequested += (_, _) => SaveLatest();
+        _toolbarWindow.CancelRequested += (_, _) => CancelLatest();
+        _toolbarWindow.Loaded += (_, _) =>
+        {
+            var bottomRight = new Point(selectionRect.Right + 12, selectionRect.Bottom + 12);
+            _toolbarWindow.PlaceAt(bottomRight, _virtualBounds);
+        };
+        _toolbarWindow.Closed += (_, _) => _toolbarWindow = null;
+        _toolbarWindow.Show();
+    }
+
+    private void PinLatest()
+    {
+        if (_latestResult == null)
+        {
+            return;
+        }
+
+        _stickyImageService.ShowStickyImage(_latestResult.Image);
+        CloseToolbar();
+    }
+
+    private void EditLatest()
+    {
+        if (_latestResult == null)
+        {
+            return;
+        }
+
+        var tempPath = Path.Combine(Path.GetTempPath(), $"screenshot-{DateTime.Now:yyyyMMddHHmmssfff}.png");
+        SaveBitmapSourceToFile(_latestResult.Image, tempPath);
+
+        try
+        {
+            var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "mspaint.exe",
+                Arguments = $"\"{tempPath}\"",
+                UseShellExecute = true
+            });
+
+            if (process != null)
+            {
+                Task.Run(() =>
+                {
+                    process.WaitForExit();
+                    TryDeleteFile(tempPath);
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Windows.MessageBox.Show($"无法打开画图程序: {ex.Message}", "WPF Screenshot", MessageBoxButton.OK, MessageBoxImage.Error);
+            TryDeleteFile(tempPath);
+        }
+
+        CloseToolbar();
+    }
+
+    private void SaveLatest()
+    {
+        if (_latestResult == null)
+        {
+            return;
+        }
+
+        SaveScreenshot(_latestResult);
+        CloseToolbar();
+    }
+
+    private void CancelLatest()
+    {
+        CloseToolbar();
+    }
+
+    private void SaveScreenshot(ScreenshotResult result)
+    {
+        var dialog = new SaveFileDialog
+        {
+            Filter = "PNG Image (*.png)|*.png|JPEG Image (*.jpg)|*.jpg",
+            FileName = $"screenshot-{result.CapturedAt:yyyyMMddHHmmss}"
+        };
+
+        if (dialog.ShowDialog() == true)
+        {
+            SaveBitmapSourceToFile(result.Image, dialog.FileName);
+            result.SavedFilePath = dialog.FileName;
+            System.Windows.MessageBox.Show($"已保存到 {dialog.FileName}", "WPF Screenshot", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+    }
+
+    private static void SaveBitmapSourceToFile(BitmapSource source, string filePath)
+    {
+        BitmapEncoder encoder = Path.GetExtension(filePath).Equals(".jpg", StringComparison.OrdinalIgnoreCase)
+            ? new JpegBitmapEncoder()
+            : new PngBitmapEncoder();
+
+        encoder.Frames.Add(BitmapFrame.Create(source));
+        using var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write);
+        encoder.Save(fileStream);
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // Ignore
+        }
+    }
+
+    private static Rect GetVirtualScreenBounds()
+    {
+        return new Rect(
+            SystemParameters.VirtualScreenLeft,
+            SystemParameters.VirtualScreenTop,
+            SystemParameters.VirtualScreenWidth,
+            SystemParameters.VirtualScreenHeight);
+    }
+
+    private static Bitmap CaptureVirtualScreen(Rect bounds)
+    {
+        var width = (int)Math.Round(bounds.Width);
+        var height = (int)Math.Round(bounds.Height);
+        var bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+        using var graphics = Graphics.FromImage(bitmap);
+        graphics.CopyFromScreen((int)Math.Round(bounds.Left), (int)Math.Round(bounds.Top), 0, 0, new System.Drawing.Size(width, height), CopyPixelOperation.SourceCopy);
+        return bitmap;
+    }
+
+    private static BitmapSource ConvertToBitmapSource(Bitmap bitmap)
+    {
+        var hBitmap = bitmap.GetHbitmap();
+        try
+        {
+            var source = System.Windows.Interop.Imaging.CreateBitmapSourceFromHBitmap(
+                hBitmap,
+                IntPtr.Zero,
+                Int32Rect.Empty,
+                BitmapSizeOptions.FromEmptyOptions());
+            source.Freeze();
+            return source;
+        }
+        finally
+        {
+            NativeMethodsWrapper.DeleteObject(hBitmap);
+        }
+    }
+
+    private void ClearOverlay()
+    {
+        _overlayWindow = null;
+        _fullScreenshot?.Dispose();
+        _fullScreenshot = null;
+    }
+
+    private void CloseToolbar()
+    {
+        if (_toolbarWindow != null)
+        {
+            _toolbarWindow.Close();
+            _toolbarWindow = null;
+        }
+    }
+
+    public void Dispose()
+    {
+        CloseToolbar();
+        _stickyImageService.CloseAll();
+        ClearOverlay();
+    }
+
+    private static class NativeMethodsWrapper
+    {
+        [System.Runtime.InteropServices.DllImport("gdi32.dll")]
+        public static extern bool DeleteObject(IntPtr hObject);
+    }
+}

--- a/src/WpfScreenshotApp/Services/StickyImageService.cs
+++ b/src/WpfScreenshotApp/Services/StickyImageService.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Windows.Media.Imaging;
+using WpfScreenshotApp.Views;
+
+namespace WpfScreenshotApp.Services;
+
+public class StickyImageService
+{
+    private readonly List<StickyImageWindow> _windows = new();
+
+    public void ShowStickyImage(BitmapSource image)
+    {
+        var window = new StickyImageWindow(image);
+        window.Closed += (_, _) => _windows.Remove(window);
+        _windows.Add(window);
+        window.Show();
+    }
+
+    public void CloseAll()
+    {
+        foreach (var window in _windows.ToArray())
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+}

--- a/src/WpfScreenshotApp/Services/TrayIconService.cs
+++ b/src/WpfScreenshotApp/Services/TrayIconService.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace WpfScreenshotApp.Services;
+
+public sealed class TrayIconService : IDisposable
+{
+    private NotifyIcon? _notifyIcon;
+    private Action? _exitAction;
+    private Action? _captureAction;
+    private Action? _saveAction;
+
+    public void Initialize(string tooltipText, Action exitAction, Action captureAction, Action saveAction)
+    {
+        _exitAction = exitAction;
+        _captureAction = captureAction;
+        _saveAction = saveAction;
+
+        _notifyIcon = new NotifyIcon
+        {
+            Text = tooltipText,
+            Visible = true,
+            Icon = SystemIcons.Application
+        };
+
+        var contextMenu = new ContextMenuStrip();
+        contextMenu.Items.Add("截图 (&S)", null, (_, _) => _captureAction?.Invoke());
+        contextMenu.Items.Add("保存最新截图 (&A)", null, (_, _) => _saveAction?.Invoke());
+        contextMenu.Items.Add(new ToolStripSeparator());
+        contextMenu.Items.Add("退出 (&E)", null, (_, _) => _exitAction?.Invoke());
+
+        _notifyIcon.ContextMenuStrip = contextMenu;
+        _notifyIcon.DoubleClick += (_, _) => _captureAction?.Invoke();
+    }
+
+    public void ShowBalloonTip(string title, string message)
+    {
+        if (_notifyIcon == null)
+        {
+            return;
+        }
+
+        _notifyIcon.BalloonTipTitle = title;
+        _notifyIcon.BalloonTipText = message;
+        _notifyIcon.ShowBalloonTip(3000);
+    }
+
+    public void Dispose()
+    {
+        if (_notifyIcon != null)
+        {
+            _notifyIcon.Visible = false;
+            _notifyIcon.Dispose();
+            _notifyIcon = null;
+        }
+    }
+}

--- a/src/WpfScreenshotApp/Views/FloatingToolbarWindow.xaml
+++ b/src/WpfScreenshotApp/Views/FloatingToolbarWindow.xaml
@@ -1,0 +1,19 @@
+<Window x:Class="WpfScreenshotApp.Views.FloatingToolbarWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        ShowInTaskbar="False"
+        Topmost="True"
+        ResizeMode="NoResize"
+        Focusable="False">
+    <Border Background="#F0FFFFFF" CornerRadius="12" BorderBrush="#FF1E88E5" BorderThickness="1" Padding="8">
+        <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="固定" Width="60" Click="OnPinClick" />
+            <Button Content="编辑" Width="60" Click="OnEditClick" />
+            <Button Content="保存" Width="60" Click="OnSaveClick" />
+            <Button Content="取消" Width="60" Click="OnCancelClick" />
+        </StackPanel>
+    </Border>
+</Window>

--- a/src/WpfScreenshotApp/Views/FloatingToolbarWindow.xaml.cs
+++ b/src/WpfScreenshotApp/Views/FloatingToolbarWindow.xaml.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Windows;
+
+namespace WpfScreenshotApp.Views;
+
+public partial class FloatingToolbarWindow : Window
+{
+    public event EventHandler? PinRequested;
+    public event EventHandler? EditRequested;
+    public event EventHandler? SaveRequested;
+    public event EventHandler? CancelRequested;
+
+    public FloatingToolbarWindow()
+    {
+        InitializeComponent();
+    }
+
+    public void PlaceAt(Point position, Rect bounds)
+    {
+        UpdateLayout();
+        var width = double.IsNaN(Width) || Width == 0 ? ActualWidth : Width;
+        var height = double.IsNaN(Height) || Height == 0 ? ActualHeight : Height;
+
+        var desiredLeft = position.X;
+        var desiredTop = position.Y;
+
+        if (desiredLeft + width > bounds.Right)
+        {
+            desiredLeft = bounds.Right - width - 10;
+        }
+
+        if (desiredTop + height > bounds.Bottom)
+        {
+            desiredTop = bounds.Bottom - height - 10;
+        }
+
+        if (desiredLeft < bounds.Left)
+        {
+            desiredLeft = bounds.Left + 10;
+        }
+
+        if (desiredTop < bounds.Top)
+        {
+            desiredTop = bounds.Top + 10;
+        }
+
+        Left = desiredLeft;
+        Top = desiredTop;
+    }
+
+    private void OnPinClick(object sender, RoutedEventArgs e) => PinRequested?.Invoke(this, EventArgs.Empty);
+
+    private void OnEditClick(object sender, RoutedEventArgs e) => EditRequested?.Invoke(this, EventArgs.Empty);
+
+    private void OnSaveClick(object sender, RoutedEventArgs e) => SaveRequested?.Invoke(this, EventArgs.Empty);
+
+    private void OnCancelClick(object sender, RoutedEventArgs e) => CancelRequested?.Invoke(this, EventArgs.Empty);
+}

--- a/src/WpfScreenshotApp/Views/OverlayWindow.xaml
+++ b/src/WpfScreenshotApp/Views/OverlayWindow.xaml
@@ -1,0 +1,25 @@
+<Window x:Class="WpfScreenshotApp.Views.OverlayWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        Topmost="True"
+        ShowInTaskbar="False"
+        ResizeMode="NoResize"
+        KeyDown="OnKeyDown"
+        MouseLeftButtonDown="OnMouseLeftButtonDown"
+        MouseMove="OnMouseMove"
+        MouseLeftButtonUp="OnMouseLeftButtonUp">
+    <Grid>
+        <Image x:Name="ScreenshotImage" Stretch="Fill" />
+        <Rectangle Fill="#80000000" />
+        <Canvas x:Name="SelectionCanvas" Background="Transparent">
+            <Border x:Name="SelectionBorder"
+                    BorderBrush="#FF64B5F6"
+                    BorderThickness="2"
+                    Background="#40FFFFFF"
+                    Visibility="Collapsed" />
+        </Canvas>
+    </Grid>
+</Window>

--- a/src/WpfScreenshotApp/Views/OverlayWindow.xaml.cs
+++ b/src/WpfScreenshotApp/Views/OverlayWindow.xaml.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media.Imaging;
+
+namespace WpfScreenshotApp.Views;
+
+public partial class OverlayWindow : Window
+{
+    private Point? _startPoint;
+    private readonly Rect _virtualBounds;
+
+    public event EventHandler<Rect>? SelectionCompleted;
+    public event EventHandler? SelectionCanceled;
+
+    public OverlayWindow(BitmapSource screenshot, Rect virtualBounds)
+    {
+        InitializeComponent();
+        _virtualBounds = virtualBounds;
+        ScreenshotImage.Source = screenshot;
+        Width = virtualBounds.Width;
+        Height = virtualBounds.Height;
+        Left = virtualBounds.Left;
+        Top = virtualBounds.Top;
+        Cursor = Cursors.Cross;
+    }
+
+    protected override void OnSourceInitialized(EventArgs e)
+    {
+        base.OnSourceInitialized(e);
+        Focus();
+        Keyboard.Focus(this);
+    }
+
+    private void OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        _startPoint = e.GetPosition(SelectionCanvas);
+        Canvas.SetLeft(SelectionBorder, _startPoint.Value.X);
+        Canvas.SetTop(SelectionBorder, _startPoint.Value.Y);
+        SelectionBorder.Width = 0;
+        SelectionBorder.Height = 0;
+        SelectionBorder.Visibility = Visibility.Visible;
+        CaptureMouse();
+    }
+
+    private void OnMouseMove(object sender, MouseEventArgs e)
+    {
+        if (_startPoint == null || e.LeftButton != MouseButtonState.Pressed)
+        {
+            return;
+        }
+
+        var currentPoint = e.GetPosition(SelectionCanvas);
+        var x = Math.Min(currentPoint.X, _startPoint.Value.X);
+        var y = Math.Min(currentPoint.Y, _startPoint.Value.Y);
+        var width = Math.Abs(currentPoint.X - _startPoint.Value.X);
+        var height = Math.Abs(currentPoint.Y - _startPoint.Value.Y);
+
+        Canvas.SetLeft(SelectionBorder, x);
+        Canvas.SetTop(SelectionBorder, y);
+        SelectionBorder.Width = width;
+        SelectionBorder.Height = height;
+    }
+
+    private void OnMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (_startPoint == null)
+        {
+            return;
+        }
+
+        ReleaseMouseCapture();
+        var currentPoint = e.GetPosition(SelectionCanvas);
+        var x = Math.Min(currentPoint.X, _startPoint.Value.X);
+        var y = Math.Min(currentPoint.Y, _startPoint.Value.Y);
+        var width = Math.Abs(currentPoint.X - _startPoint.Value.X);
+        var height = Math.Abs(currentPoint.Y - _startPoint.Value.Y);
+        _startPoint = null;
+
+        if (width < 5 || height < 5)
+        {
+            SelectionBorder.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        SelectionCompleted?.Invoke(this, new Rect(x + _virtualBounds.Left, y + _virtualBounds.Top, width, height));
+    }
+
+    private void OnKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            SelectionCanceled?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/src/WpfScreenshotApp/Views/StickyImageWindow.xaml
+++ b/src/WpfScreenshotApp/Views/StickyImageWindow.xaml
@@ -1,0 +1,18 @@
+<Window x:Class="WpfScreenshotApp.Views.StickyImageWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Width="300"
+        Height="200"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        Topmost="True"
+        ShowInTaskbar="False"
+        ResizeMode="NoResize"
+        SizeToContent="WidthAndHeight"
+        MouseLeftButtonDown="OnMouseLeftButtonDown"
+        MouseDoubleClick="OnMouseDoubleClick">
+    <Border BorderBrush="#FF0078D7" BorderThickness="2" CornerRadius="8" Background="#F0FFFFFF" Padding="8">
+        <Image x:Name="StickyImage" Stretch="Uniform" />
+    </Border>
+</Window>

--- a/src/WpfScreenshotApp/Views/StickyImageWindow.xaml.cs
+++ b/src/WpfScreenshotApp/Views/StickyImageWindow.xaml.cs
@@ -1,0 +1,27 @@
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media.Imaging;
+
+namespace WpfScreenshotApp.Views;
+
+public partial class StickyImageWindow : Window
+{
+    public StickyImageWindow(BitmapSource image)
+    {
+        InitializeComponent();
+        StickyImage.Source = image;
+    }
+
+    private void OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ButtonState == MouseButtonState.Pressed)
+        {
+            DragMove();
+        }
+    }
+
+    private void OnMouseDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        Close();
+    }
+}

--- a/src/WpfScreenshotApp/WpfScreenshotApp.csproj
+++ b/src/WpfScreenshotApp/WpfScreenshotApp.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net7.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- create a .NET 7 WPF project scaffold with tray icon startup workflow and global hotkey registration
- add overlay capture flow with floating toolbar actions for pinning, editing in Paint, saving, and clipboard integration
- implement sticky image notes, clipboard helper services, and solution configuration for Visual Studio

## Testing
- not run (toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e282f510d483309e74e8fa924637e2