### PR TITLE
Update capture workflow and hotkey

### DIFF
--- a/src/WpfScreenshotApp/App.xaml.cs
+++ b/src/WpfScreenshotApp/App.xaml.cs
@@ -25,12 +25,12 @@ public partial class App : System.Windows.Application
 
         _hotkeyService = new HotkeyService();
         _hotkeyService.HotkeyPressed += (_, _) => StartCapture();
-        if (!_hotkeyService.RegisterHotkey(ModifierKeys.Control | ModifierKeys.Alt, System.Windows.Forms.Keys.End))
+        if (!_hotkeyService.RegisterHotkey(ModifierKeys.Control | ModifierKeys.Alt, System.Windows.Forms.Keys.A))
         {
-            System.Windows.Forms.MessageBox.Show("无法注册全局热键 Ctrl+Alt+End，可能已被其他程序占用。", "WPF Screenshot", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            System.Windows.Forms.MessageBox.Show("无法注册全局热键 Ctrl+Alt+A，可能已被其他程序占用。", "WPF Screenshot", MessageBoxButtons.OK, MessageBoxIcon.Warning);
         }
 
-        Dispatcher.BeginInvoke(new Action(() => _trayIconService?.ShowBalloonTip("已启动", "按 Ctrl+Alt+End 开始截图")));
+        Dispatcher.BeginInvoke(new Action(() => _trayIconService?.ShowBalloonTip("已启动", "按 Ctrl+Alt+A 开始截图")));
     }
 
     private void StartCapture()

--- a/src/WpfScreenshotApp/Models/SelectionCompletedEventArgs.cs
+++ b/src/WpfScreenshotApp/Models/SelectionCompletedEventArgs.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Windows;
+
+namespace WpfScreenshotApp.Models;
+
+public sealed class SelectionCompletedEventArgs : EventArgs
+{
+    public SelectionCompletedEventArgs(Rect selection, Point releasePoint)
+    {
+        Selection = selection;
+        ReleasePoint = releasePoint;
+    }
+
+    public Rect Selection { get; }
+
+    public Point ReleasePoint { get; }
+}

--- a/src/WpfScreenshotApp/Views/FloatingToolbarWindow.xaml
+++ b/src/WpfScreenshotApp/Views/FloatingToolbarWindow.xaml
@@ -7,13 +7,14 @@
         ShowInTaskbar="False"
         Topmost="True"
         ResizeMode="NoResize"
-        Focusable="False">
-    <Border Background="#F0FFFFFF" CornerRadius="12" BorderBrush="#FF1E88E5" BorderThickness="1" Padding="8">
-        <StackPanel Orientation="Horizontal">
-            <Button Content="固定" Width="60" Click="OnPinClick" />
-            <Button Content="编辑" Width="60" Click="OnEditClick" />
-            <Button Content="保存" Width="60" Click="OnSaveClick" />
-            <Button Content="取消" Width="60" Click="OnCancelClick" />
+        Focusable="False"
+        SizeToContent="WidthAndHeight">
+    <Border Background="#F0FFFFFF" CornerRadius="10" BorderBrush="#FF1E88E5" BorderThickness="1" Padding="6">
+        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+            <Button Content="固定" MinWidth="44" Height="30" FontSize="12" Padding="6,2" Margin="0,0,6,0" Click="OnPinClick" />
+            <Button Content="编辑" MinWidth="44" Height="30" FontSize="12" Padding="6,2" Margin="0,0,6,0" Click="OnEditClick" />
+            <Button Content="保存" MinWidth="44" Height="30" FontSize="12" Padding="6,2" Margin="0,0,6,0" Click="OnSaveClick" />
+            <Button Content="取消" MinWidth="44" Height="30" FontSize="12" Padding="6,2" Click="OnCancelClick" />
         </StackPanel>
     </Border>
 </Window>

--- a/src/WpfScreenshotApp/Views/StickyImageWindow.xaml
+++ b/src/WpfScreenshotApp/Views/StickyImageWindow.xaml
@@ -1,8 +1,6 @@
 <Window x:Class="WpfScreenshotApp.Views.StickyImageWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Width="300"
-        Height="200"
         WindowStyle="None"
         AllowsTransparency="True"
         Background="Transparent"
@@ -13,6 +11,6 @@
         MouseLeftButtonDown="OnMouseLeftButtonDown"
         MouseDoubleClick="OnMouseDoubleClick">
     <Border BorderBrush="#FF0078D7" BorderThickness="2" CornerRadius="8" Background="#F0FFFFFF" Padding="8">
-        <Image x:Name="StickyImage" Stretch="Uniform" />
+        <Image x:Name="StickyImage" Stretch="None" />
     </Border>
 </Window>

--- a/src/WpfScreenshotApp/Views/StickyImageWindow.xaml.cs
+++ b/src/WpfScreenshotApp/Views/StickyImageWindow.xaml.cs
@@ -10,6 +10,10 @@ public partial class StickyImageWindow : Window
     {
         InitializeComponent();
         StickyImage.Source = image;
+        var dpiX = image.DpiX <= 0 ? 96d : image.DpiX;
+        var dpiY = image.DpiY <= 0 ? 96d : image.DpiY;
+        StickyImage.Width = image.PixelWidth * 96d / dpiX;
+        StickyImage.Height = image.PixelHeight * 96d / dpiY;
     }
 
     private void OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)

--- a/src/WpfScreenshotApp/WpfScreenshotApp.csproj
+++ b/src/WpfScreenshotApp/WpfScreenshotApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- upgrade the WPF project to .NET 8
- change the global hotkey to Ctrl+Alt+A and keep the overlay visible while showing a compact toolbar near the selection
- ensure pinned screenshots match the captured region size

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e31b8bed688330b2f379ca37cfc20a